### PR TITLE
Add species overrides; merge flycatchers into Western Flycatcher

### DIFF
--- a/birdweather_exhibit/lib/config/species_overrides.dart
+++ b/birdweather_exhibit/lib/config/species_overrides.dart
@@ -1,0 +1,151 @@
+import "package:birdweather_exhibit/graphql/topBirdWeatherSpecies.graphql.dart";
+
+/// A rename/merge rule for BirdWeather species.
+///
+/// Any API species whose common name is listed in [sourceCommonNames] is
+/// displayed as [displayCommonName] (and the other `display*` fields when set).
+/// When several source species share one display name they are treated as a
+/// single species: their Top Detections counts are summed and they collapse to
+/// one recent-detection card.
+///
+/// To rename or merge more species, add entries to [speciesOverrides].
+class SpeciesOverride {
+  const SpeciesOverride({
+    required this.sourceCommonNames,
+    required this.displayCommonName,
+    this.displayScientificName,
+    this.displayDescription,
+    this.displayImageUrl,
+    this.displayThumbnailUrl,
+  });
+
+  /// API common names that should be treated as [displayCommonName].
+  final List<String> sourceCommonNames;
+  final String displayCommonName;
+  final String? displayScientificName;
+
+  /// A description for the merged species. When set it replaces the per-species
+  /// description so the merged card reads consistently regardless of which
+  /// source species was detected.
+  final String? displayDescription;
+
+  /// A photo for the merged species (full image and thumbnail). When set it
+  /// replaces the per-species photos.
+  final String? displayImageUrl;
+  final String? displayThumbnailUrl;
+}
+
+/// The list of species name exceptions. Edit this to rename or merge species.
+const List<SpeciesOverride> speciesOverrides = [
+  // The Cordilleran and Pacific-slope Flycatchers were re-lumped into a single
+  // species, the Western Flycatcher. Show them as one bird with a combined
+  // detection count, a single description, and one pinned photo so the Top
+  // Detections and recent-detection cards always show the same image.
+  SpeciesOverride(
+    sourceCommonNames: ["Cordilleran Flycatcher", "Pacific-slope Flycatcher"],
+    displayCommonName: "Western Flycatcher",
+    displayScientificName: "Empidonax difficilis",
+    displayDescription:
+        "The Western Flycatcher is a small olive-and-yellow flycatcher of "
+        "western forests, named for the way it darts out from a perch to snap "
+        "up flying insects. Until recently it was split into two species: the "
+        "coastal Pacific-slope and the inland Cordilleran Flycatcher. In 2023, "
+        "ornithologists merged them back into a single species, the Western "
+        "Flycatcher — a reminder that scientific understanding keeps "
+        "evolving. It favors shaded forests near flowing water, especially "
+        "canyons and ravines where breaks in the canopy create insect-rich "
+        "hunting grounds. Like other Empidonax flycatchers, it is far easier "
+        "to recognize by its sharp call than by sight, and males sing "
+        "persistently through the early weeks of nesting season.\n\n"
+        "(Cornell Lab of Ornithology All About Birds)",
+    // Pinned so both columns match (otherwise each picks its own subspecies
+    // photo — Top Detections by count, recent detections by recency). Swap to a
+    // Pacific-slope image here if preferred.
+    displayImageUrl:
+        "https://media.birdweather.com/species/1787/CordilleranFlycatcher-standard-a12e29a7b443451f9ecaab1360386ead.jpg",
+    displayThumbnailUrl:
+        "https://media.birdweather.com/species/1787/CordilleranFlycatcher-thumbnail-af713c20c740779eda295b294cee0ba6.jpg",
+  ),
+];
+
+SpeciesOverride? _overrideForCommonName(String? commonName) {
+  if (commonName == null) return null;
+  for (final override in speciesOverrides) {
+    if (override.sourceCommonNames.contains(commonName)) return override;
+  }
+  return null;
+}
+
+/// The common name to display for an API species (unchanged if no override).
+String displayCommonName(String apiCommonName) =>
+    _overrideForCommonName(apiCommonName)?.displayCommonName ?? apiCommonName;
+
+/// The scientific name to display: the override's value when provided,
+/// otherwise the API value.
+String? displayScientificName(
+        String apiCommonName, String? apiScientificName) =>
+    _overrideForCommonName(apiCommonName)?.displayScientificName ??
+    apiScientificName;
+
+/// The description to display: the override's value when provided, otherwise
+/// [fallbackDescription] (typically the per-species resolved description).
+String displayDescription(String apiCommonName, String fallbackDescription) =>
+    _overrideForCommonName(apiCommonName)?.displayDescription ??
+    fallbackDescription;
+
+/// The image URL to display: the override's value when provided, otherwise the
+/// API value.
+String? displayImageUrl(String apiCommonName, String? apiImageUrl) =>
+    _overrideForCommonName(apiCommonName)?.displayImageUrl ?? apiImageUrl;
+
+/// The thumbnail URL to display: the override's value when provided, otherwise
+/// the API value.
+String? displayThumbnailUrl(String apiCommonName, String? apiThumbnailUrl) =>
+    _overrideForCommonName(apiCommonName)?.displayThumbnailUrl ??
+    apiThumbnailUrl;
+
+/// A key that is identical for every API species merged into one display
+/// species — use it to de-duplicate/group detections. Falls back to
+/// [fallbackKey] (e.g. the species id) when there is no override.
+String canonicalSpeciesKey(String? apiCommonName, String fallbackKey) =>
+    _overrideForCommonName(apiCommonName)?.displayCommonName ?? fallbackKey;
+
+/// Applies [speciesOverrides] to a Top Detections result: renames overridden
+/// species and merges those that share a display name, summing their counts.
+/// The resulting list is re-sorted by count (descending).
+Query$TopBirdWeatherSpecies applyOverridesToTopSpecies(
+    Query$TopBirdWeatherSpecies data) {
+  final merged = <String, Query$TopBirdWeatherSpecies$species>{};
+
+  for (final entry in data.species) {
+    final key = canonicalSpeciesKey(entry.species?.commonName, entry.speciesId);
+    final existing = merged[key];
+    if (existing == null) {
+      merged[key] = _renameEntry(entry);
+    } else {
+      merged[key] = existing.copyWith(count: existing.count + entry.count);
+    }
+  }
+
+  final mergedList = merged.values.toList()
+    ..sort((a, b) => b.count.compareTo(a.count));
+
+  return data.copyWith(species: mergedList);
+}
+
+/// Returns [entry] with its species renamed/re-photographed per any override.
+Query$TopBirdWeatherSpecies$species _renameEntry(
+    Query$TopBirdWeatherSpecies$species entry) {
+  final species = entry.species;
+  final override = _overrideForCommonName(species?.commonName);
+  if (species == null || override == null) return entry;
+
+  return entry.copyWith(
+    species: species.copyWith(
+      commonName: override.displayCommonName,
+      scientificName: override.displayScientificName ?? species.scientificName,
+      thumbnailUrl: override.displayThumbnailUrl ?? species.thumbnailUrl,
+      imageUrl: override.displayImageUrl ?? species.imageUrl,
+    ),
+  );
+}

--- a/birdweather_exhibit/lib/services/bird_weather_service.dart
+++ b/birdweather_exhibit/lib/services/bird_weather_service.dart
@@ -77,7 +77,10 @@ class BirdWeatherService {
           Options$Query$TopBirdWeatherSpecies(
             variables: Variables$Query$TopBirdWeatherSpecies(
               period: Input$InputDuration(count: 24, unit: "hour"),
-              limit: 10,
+              // Fetch more than we display (top 10) so species-merge overrides
+              // can still combine a lower-ranked partner species before the UI
+              // trims the list. See applyOverridesToTopSpecies.
+              limit: 30,
               stationIds: [_config.stationId],
             ),
           ),

--- a/birdweather_exhibit/lib/species_information/live_detection/live_detection_notifier.dart
+++ b/birdweather_exhibit/lib/species_information/live_detection/live_detection_notifier.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:birdweather_exhibit/config/species_overrides.dart";
 import "package:birdweather_exhibit/graphql/mobileDetections.graphql.dart";
 import "package:birdweather_exhibit/services/bird_weather_service.dart";
 import "package:birdweather_exhibit/providers/species_description_provider.dart";
@@ -17,7 +18,9 @@ class LiveDetectionNotifier extends _$LiveDetectionNotifier {
   @override
   FutureOr<LiveDetectionState> build() async {
     final birdWeatherService = ref.read(birdWeatherServiceProvider);
-    final detectionData = await birdWeatherService.getDetectionData(limit: 10);
+    // Fetch a wide window of recent detections so we can still surface 3
+    // distinct species when one species floods the most recent detections.
+    final detectionData = await birdWeatherService.getDetectionData(limit: 50);
 
     // Initialize the local list with the first 3 unique species
     final allDetections =
@@ -48,7 +51,7 @@ class LiveDetectionNotifier extends _$LiveDetectionNotifier {
     if (currentState is LiveDetectionLoadedState) {
       final birdWeatherService = ref.read(birdWeatherServiceProvider);
       final detectionData =
-          await birdWeatherService.getDetectionData(limit: 10);
+          await birdWeatherService.getDetectionData(limit: 50);
 
       // Get all new detections
       final allDetections =
@@ -75,17 +78,19 @@ class LiveDetectionNotifier extends _$LiveDetectionNotifier {
     final Map<String, Query$MobileDetections$detections$nodes> uniqueSpecies =
         {};
 
-    // Get unique species (newest detection for each species)
+    // Get unique species (newest detection for each species). Merged species
+    // (per the overrides) share a canonical key so they collapse to one card.
     for (final detection in allDetections) {
       if (detection == null) continue;
 
-      final speciesId = detection.species.id;
+      final speciesKey = canonicalSpeciesKey(
+          detection.species.commonName, detection.species.id);
       final timestamp = detection.timestamp!;
 
-      if (!uniqueSpecies.containsKey(speciesId) ||
+      if (!uniqueSpecies.containsKey(speciesKey) ||
           DateTime.parse(timestamp)
-              .isAfter(DateTime.parse(uniqueSpecies[speciesId]!.timestamp!))) {
-        uniqueSpecies[speciesId] = detection;
+              .isAfter(DateTime.parse(uniqueSpecies[speciesKey]!.timestamp!))) {
+        uniqueSpecies[speciesKey] = detection;
       }
     }
 
@@ -126,12 +131,16 @@ class LiveDetectionNotifier extends _$LiveDetectionNotifier {
     for (final detection in allDetections) {
       if (detection == null) continue;
 
-      final speciesId = detection.species.id;
+      final speciesKey = canonicalSpeciesKey(
+          detection.species.commonName, detection.species.id);
       final timestamp = detection.timestamp!;
 
-      // Check if this species is already in our local list
-      final existingIndex = _localDetectionList
-          .indexWhere((d) => d.detection.species.id == speciesId);
+      // Check if this species is already in our local list (canonical key so
+      // merged species are matched together).
+      final existingIndex = _localDetectionList.indexWhere((d) =>
+          canonicalSpeciesKey(
+              d.detection.species.commonName, d.detection.species.id) ==
+          speciesKey);
 
       if (existingIndex != -1) {
         // Species exists in local list - only replace if this detection is newer

--- a/birdweather_exhibit/lib/species_information/live_detection/recent_detections.dart
+++ b/birdweather_exhibit/lib/species_information/live_detection/recent_detections.dart
@@ -1,3 +1,4 @@
+import "package:birdweather_exhibit/config/species_overrides.dart";
 import "package:birdweather_exhibit/species_information/live_detection/components/detection_card.dart";
 import "package:birdweather_exhibit/species_information/live_detection/live_detection_notifier.dart";
 import "package:flutter/material.dart";
@@ -62,12 +63,23 @@ class _FloatingRecentDetectionState extends ConsumerState<RecentDetections>
                       const SizedBox(height: 16), // Spacing between cards
                     AnimatedDetectionCard(
                       detectionId: detectionId,
-                      imageUrl: detection.species.imageUrl!,
-                      commonName: detection.species.commonName,
-                      scientificName: detection.species.scientificName!,
+                      imageUrl: displayImageUrl(
+                            detection.species.commonName,
+                            detection.species.imageUrl,
+                          ) ??
+                          detection.species.imageUrl!,
+                      commonName: displayCommonName(detection.species.commonName),
+                      scientificName: displayScientificName(
+                            detection.species.commonName,
+                            detection.species.scientificName,
+                          ) ??
+                          detection.species.scientificName!,
                       timestamp: detection.timestamp!,
                       isLive: detectionWithStatus.isLive,
-                      description: detectionWithStatus.resolvedDescription,
+                      description: displayDescription(
+                        detection.species.commonName,
+                        detectionWithStatus.resolvedDescription,
+                      ),
                       slideAnimation: _slideAnimations[detectionId],
                       fadeAnimation: _fadeAnimations[detectionId],
                     ),

--- a/birdweather_exhibit/lib/species_information/top_species/top_species_notifier.dart
+++ b/birdweather_exhibit/lib/species_information/top_species/top_species_notifier.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:birdweather_exhibit/config/species_overrides.dart";
 import "package:birdweather_exhibit/services/bird_weather_service.dart";
 import "package:birdweather_exhibit/species_information/top_species/top_species_state.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
@@ -14,11 +15,14 @@ class TopSpeciesNotifier extends _$TopSpeciesNotifier {
   FutureOr<TopSpeciesState> build() async {
     final birdWeatherService = ref.read(birdWeatherServiceProvider);
     final topSpecies = await birdWeatherService.getTopBirdWeatherSpecies();
+    // Merge/rename species per the configured exceptions (e.g. Cordilleran +
+    // Pacific-slope Flycatcher -> Western Flycatcher with combined counts).
+    final mergedTopSpecies = applyOverridesToTopSpecies(topSpecies);
     final sensorData = await birdWeatherService.getStationSensorData();
     final lastUpdated = DateTime.now();
     _autoUpdateTopDetections();
     return TopSpeciesState(
-      topSpecies: topSpecies,
+      topSpecies: mergedTopSpecies,
       lastUpdated: lastUpdated,
       sensorData: sensorData,
     );


### PR DESCRIPTION
Add a configurable species exceptions list (lib/config/species_overrides.dart) that can rename API species and merge several into one for display, with optional custom description and photo. The first rule merges Cordilleran + Pacific-slope Flycatcher into "Western Flycatcher".

- Top Detections: merge matching entries, sum their counts, re-sort, and apply the override name/photo. Top-species fetch limit raised 10 -> 30 so a lower-ranked partner species is still captured before the UI trims to 10.
- Recent detections: display the overridden name, photo, and description, and de-duplicate merged species via a canonical key so they collapse to one card.
- Widen the recent-detection fetch (10 -> 50) so 3 distinct species still surface when one species floods the most recent detections.